### PR TITLE
Use unminified smooth-scroll file as main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "smooth-scroll",
 	"version": "11.1.0",
 	"description": "Animate scrolling to anchor links",
-	"main": "./dist/js/smooth-scroll.min.js",
+	"main": "./dist/js/smooth-scroll.js",
 	"author": {
 		"name": "Chris Ferdinandi",
 		"url": "http://gomakethings.com"


### PR DESCRIPTION
This fixes an issue where Smooth Scroll breaks, when it’s bundled up and uglified (again). 

In my setup (npm, Gulp, Webpack, CommonJS...) SmoothScroll breaks only on production. It works on the development system, because there doesn’t happen any minification. On production the whole code is minified and due to the `"main": "./dist/js/smooth-scroll.min.js"` property, it tells the bundler to use the already minified Smooth Scroll version and uglifies it again. 

It then throws
```
Uncaught TypeError: Cannot read property 'hostname' of undefined
```
meaning this line of code:
```
... o.location.hostname&&i.pathname===o.location.pathname ...
```

This is because `o` as a variable exits twice now, in the bundled up and uglified code. Using the unminified file like in this pull request let’s the bundler and uglifier work with the original variable names and it can come up with a proper uglified version for it.